### PR TITLE
add shortcuts to focus search bar

### DIFF
--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -342,6 +342,7 @@
             searchInput.selectionStart = searchInput.selectionEnd = searchInput.value.length;
         }
     });
+
 </script>
 
 {% endblock %}

--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -332,6 +332,15 @@
     liveSort("catalogGoodQuality");
     liveSort("catalogLowQuality");
 
+    document.addEventListener('keydown', function(event) {
+        // focus search bar when either <ctrl>+<k> was typed or <shift>+<7> ("/") or just the num pad "/" 
+        if ((event.key === 'k' && event.ctrlKey) || (event.key === '/' && event.shiftKey) || (event.key === '/')) {
+            event.preventDefault();
+            // focus search bar and set the cursor at the end of the already entered input
+            searchInput.focus();
+            searchInput.selectionStart = searchInput.selectionEnd = searchInput.value.length;
+        }
+    });
 </script>
 
 {% endblock %}

--- a/templates/wishlist.html
+++ b/templates/wishlist.html
@@ -279,6 +279,16 @@
     liveSearch();
     liveSort("wishlist");
 
+    document.addEventListener('keydown', function(event) {
+        // focus search bar when either <ctrl>+<k> was typed or <shift>+<7> ("/") or just the num pad "/" 
+        if ((event.key === 'k' && event.ctrlKey) || (event.key === '/' && event.shiftKey) || (event.key === '/')) {
+            event.preventDefault();
+            // focus search bar and set the cursor at the end of the already entered input
+            searchInput.focus();
+            searchInput.selectionStart = searchInput.selectionEnd = searchInput.value.length;
+        }
+    });
+
 </script>
 
 {% endblock %}


### PR DESCRIPTION
- focus the search bar when one of the following shortcuts is typed
    - `ctrl`+`k`
    - `shift`+`7` (slash)
    - `/` (numpad slash)
- I don't want to have to use my mouse to select the search box.
- In most places you can use `/` to search. Github, gitlab, google search, ... and it's the default vi key for search.
- `ctrl`+`k` is a very common one as well, e.g.:
    - https://hub.docker.com/
    - https://docs.docker.com/
    - https://piped.video/
    - https://laravel.com/docs/11.x
    - https://svelte.dev/
    - https://react.dev/
    - https://vuejs.org/
    - https://vuetifyjs.com/en/
    - https://tailwindcss.com/
    - https://getbootstrap.com/
    - Thunderbird (version 8 and later): Search All Messages (Global Search)
    - https://github.com/ uses `/` and `ctrl`+`k` too
    - https://getcomposer.org/doc/
    - https://podman-desktop.io/