### PR TITLE
Disable spellcheck

### DIFF
--- a/templates/catalog.html
+++ b/templates/catalog.html
@@ -92,6 +92,7 @@
                 id="search"
                 autofocus
                 placeholder="{{ _('Search for…') }}"
+                spellcheck="false"
                 {% if request.args.get("search") %}value="{{ request.args.get("search") }}"{% endif %}
                 class="w-full sm:text-sm py-2 pe-10"
             >

--- a/templates/wishlist.html
+++ b/templates/wishlist.html
@@ -19,6 +19,7 @@
                 type="text"
                 id="search"
                 autofocus
+                spellcheck="false"
                 {% if request.args.get("search") %}value="{{ request.args.get("search") }}"{% endif %}
                 placeholder="{{ _('Search for…') }}"
                 class="w-full sm:text-sm py-2 pe-10"

--- a/templates/wishlist_add.html
+++ b/templates/wishlist_add.html
@@ -59,7 +59,7 @@
       <input name="csrf_token" type="text" class="hidden" value="{{ csrf_token }}" >
 
       <label for="name" class="mt-5 block font-bold text-gray-700">{{ _("Name") }}</label>
-      <input name="name" type="text" autofocus class="w-full mt-1" maxlength="30" required onkeyup="this.value = this.value.replace(/[^a-zA-Z0-9.-\\(\\)\\ ]/, '')" >
+      <input name="name" type="text" spellcheck="false" autofocus class="w-full mt-1"  maxlength="30" required onkeyup="this.value = this.value.replace(/[^a-zA-Z0-9.-\\(\\)\\ ]/, '')" >
 
       <label for="description" class="mt-5 block font-bold text-gray-700">{{ _("App's description") }}</label>
       <textarea name="description" type="text" class="w-full mt-1 rounded-md border-gray-200 text-gray-700 shadow-sm" required rows='3' maxlength='100'></textarea>


### PR DESCRIPTION
on mobile i tried to search for the `shiori` app and it was automatically "corrected" to `shooting`, really annoying...

so this PR disables spellcheck for the search input (catalog & wishlist) and also for the app name on the `wishlist_add` page